### PR TITLE
Style tidy

### DIFF
--- a/assets/css/mcrgreyhats.css
+++ b/assets/css/mcrgreyhats.css
@@ -23,6 +23,14 @@ a.icon:hover {
 	cursor: inherit;
 }
 
+/** Reduce vertical spacing between sections. **/
+body > div.style1,
+body > div.style2,
+body > div.style3,
+body > div.style4 {
+	padding: 4em 0;
+}
+
 /** Nav & hackthebox section. **/
 .hackthebox {
     display: block;

--- a/assets/css/mcrgreyhats.css
+++ b/assets/css/mcrgreyhats.css
@@ -79,3 +79,24 @@ body > div.style4 {
 #contact header {
 	margin-bottom: 0;
 }
+
+/** Missing/incorrect icon colours **/
+ul.social li a.fa-github {
+	background-color: #4078c0;
+}
+
+ul.social li a.fa-meetup {
+	background-color: #e0393e;
+}
+
+ul.social li a.fa-envelope-o {
+	background-color: #ccc;
+}
+
+ul.social li a.fa-reddit {
+	background-color: #5f99cf;
+}
+
+ul.social li a.fa-slack {
+	background-color: #3eb991;
+}

--- a/assets/css/mcrgreyhats.css
+++ b/assets/css/mcrgreyhats.css
@@ -100,3 +100,75 @@ ul.social li a.fa-reddit {
 ul.social li a.fa-slack {
 	background-color: #3eb991;
 }
+
+/** Mobile sizes **/
+@media screen and (max-width: 737px)  {
+	.logo,
+	.logo span.image,
+	.logo img {
+		height: 250px;
+	}
+	.logo img {
+		width: 250px;
+	}
+	.title p {
+		padding: 0 3em;
+	}
+
+	header > p {
+	    font-size: 1em;
+	}
+}
+
+/** Above Mobile and below Desktop sizes. **/
+@media screen and (max-width: 1200px) and (min-width: 737px) {
+	header {
+	    margin: 0 0 1em 0;
+	}
+
+	header h1 {
+	    margin: 0;
+	}
+
+	.wrapper.first {
+	    padding-top: 4em;
+	}
+}
+
+/** Smaller than desktop size **/
+@media screen and (max-width: 1200px)  {
+	body, input, textarea, select {
+	    line-height: 1.75em;
+	    font-size: 14pt;
+	    letter-spacing: 0;
+	}
+
+	h1 {
+		font-size: 2.5em;
+	}
+
+	h2, h3, h4, h5, h6 {
+	    font-size: 2em;
+	}
+
+	nav {
+		height: 3.25em;
+	}
+
+	.logo,
+	.logo span.image,
+	.logo img {
+		height: 250px;
+	}
+	.logo img {
+		width: 250px;
+		margin: 0 auto;
+	}
+
+	body > div.style1,
+	body > div.style2,
+	body > div.style3,
+	body > div.style4 {
+		padding: 1em 0;
+	}
+}

--- a/assets/css/mcrgreyhats.css
+++ b/assets/css/mcrgreyhats.css
@@ -22,3 +22,28 @@ a.icon:hover {
 .icon.featured:hover {
 	cursor: inherit;
 }
+
+/** Nav & hackthebox section. **/
+.hackthebox {
+    display: block;
+    position: relative;
+    width: 100%;
+    height: 100px;
+    top: 3.25em;
+    left: 0;
+    padding: 0;
+    margin: 0;
+    background-color: #444;
+    text-align: center;
+    z-index: 0;
+}
+
+.hackthebox > div {
+	margin: 0 auto;
+}
+
+#nav > .container:after {
+	content: "";
+	display: table;
+	clear: both;
+}

--- a/assets/css/mcrgreyhats.css
+++ b/assets/css/mcrgreyhats.css
@@ -65,6 +65,10 @@ body > div.style4 {
 	margin-bottom: 0.25em;
 }
 
+.logo {
+	margin-bottom: 2em;
+}
+
 /** Who we are section. **/
 .about-body {
 	margin: 0 3em;

--- a/assets/css/mcrgreyhats.css
+++ b/assets/css/mcrgreyhats.css
@@ -64,3 +64,9 @@ body > div.style4 {
 .title p {
 	margin-bottom: 0.25em;
 }
+
+/** Who we are section. **/
+.about-body {
+	margin: 0 3em;
+	text-align: left;
+}

--- a/assets/css/mcrgreyhats.css
+++ b/assets/css/mcrgreyhats.css
@@ -74,3 +74,8 @@ body > div.style4 {
 	margin: 0 3em;
 	text-align: left;
 }
+
+/** Contact section. **/
+#contact header {
+	margin-bottom: 0;
+}

--- a/assets/css/mcrgreyhats.css
+++ b/assets/css/mcrgreyhats.css
@@ -80,6 +80,10 @@ body > div.style4 {
 	margin-bottom: 0;
 }
 
+#contact header p {
+	padding: 0 1em;
+}
+
 /** Missing/incorrect icon colours **/
 ul.social li a.fa-github {
 	background-color: #4078c0;

--- a/assets/css/mcrgreyhats.css
+++ b/assets/css/mcrgreyhats.css
@@ -55,3 +55,12 @@ body > div.style4 {
 	display: table;
 	clear: both;
 }
+
+/** Site header and logo section. **/
+.title {
+	float: right;
+}
+
+.title p {
+	margin-bottom: 0.25em;
+}

--- a/assets/css/mcrgreyhats.css
+++ b/assets/css/mcrgreyhats.css
@@ -1,0 +1,24 @@
+/**
+ * mcrgreyhats.css
+ *
+ * A bunch of customisations and improvements from the original theme.
+ * These are written purely in CSS for simplicity (and because the theme
+ * SASS doesn't include a config.rb or equivalent for settings).
+ **/
+
+/** Links section. **/
+a {
+	text-decoration: none;
+}
+
+a:hover {
+	text-decoration: underline;
+}
+
+a.icon:hover {
+	text-decoration: none;
+}
+
+.icon.featured:hover {
+	cursor: inherit;
+}

--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
 	<body>
 		<!-- Nav -->
 		<nav id="nav">
-			HackTheBox Team Score:<script src="https://www.hackthebox.eu/badge/team/189"></script>!
 			<ul class="container">
 				<li><a href="#top">Top</a></li>
 				<li><a href="https://blog.manchestergreyhats.co.uk/">Blog</a></li>
@@ -26,6 +25,7 @@
 				<li><a href="#contact">Contact</a></li>
 			</ul>
 		</nav>
+		<div class="hackthebox">HackTheBox Team Score:<script src="https://www.hackthebox.eu/badge/team/189"></script></div>
 
 		<!-- Home -->
 		<div class="wrapper style1 first">

--- a/index.html
+++ b/index.html
@@ -51,15 +51,18 @@
 			<article id="about">
 				<header>
 					<h2>Who are we?</h2>
-					<p>Manchester Grey Hats is a place for all those interested in hacking and cyber security to learn and share. We run capture the flags, workshops and perform/present security research.
-
-We encourage all skill levels and those from all backgrounds. Are you an aspiring hacker or a developer thinking about security? Come along and learn. Presenting is open to all members, so if you have something you’d like to present but aren’t ready for the big conferences, get in touch.
-
-Said best by The Mentor – “This is our world now… the world of the electron and the switch, the beauty of the baud”
-
-Although we meet face to face once a month, MGH is mostly an online community. We encourge people to join us in person for workshops and events but if you can't, join us on Slack and our live stream.
-</p>
 				</header>
+
+				<div class="about-body">
+					<p>Manchester Grey Hats is a place for all those interested in hacking and cyber security to learn and share. We run capture the flags, workshops and perform/present security research.</p>
+
+					<p>We encourage all skill levels and those from all backgrounds. Are you an aspiring hacker or a developer thinking about security? Come along and learn. Presenting is open to all members, so if you have something you’d like to present but aren’t ready for the big conferences, get in touch.</p>
+
+					<p>Said best by The Mentor – “This is our world now… the world of the electron and the switch, the beauty of the baud”</p>
+
+					<p>Although we meet face to face once a month, MGH is mostly an online community. We encourge people to join us in person for workshops and events but if you can't, join us on Slack and our live stream.</p>
+				</div>
+
 				<div class="container">
 					<div class="row">
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<!--[if lte IE 8]><script src="assets/js/ie/html5shiv.js"></script><![endif]-->
 		<link rel="stylesheet" href="assets/css/main.css" />
+		<link rel="stylesheet" href="assets/css/mcrgreyhats.css" />
 		<!--[if lte IE 8]><link rel="stylesheet" href="assets/css/ie8.css" /><![endif]-->
 		<!--[if lte IE 9]><link rel="stylesheet" href="assets/css/ie9.css" /><![endif]-->
 	</head>

--- a/index.html
+++ b/index.html
@@ -31,15 +31,16 @@
 		<div class="wrapper style1 first">
 			<article class="container" id="top">
 				<div class="row">
-					<div class="4u 12u(mobile)">
-						<span class="image fit"><img src="images/pic00.jpg" alt="" /></span>
-					</div>
-					<div class="8u 12u(mobile)">
+					<div class="8u 12u(mobile) title">
 						<header>
 							<h1>Manchester Grey Hats</h1>
 						</header>
-						<p>Hack the planet! Fourth Wednesday of the month, 7PM at MadLab, Manchester</p>
-
+						<p>Hack the planet!</p>
+						<p>Fourth Wednesday of the month</p>
+						<p>7PM at <a href="https://madlab.org.uk">MadLab</a>, Manchester</p>
+					</div>
+					<div class="4u 12u(mobile) logo">
+						<span class="image fit"><img src="images/pic00.jpg" alt="" /></span>
 					</div>
 				</div>
 			</article>

--- a/index.html
+++ b/index.html
@@ -66,51 +66,41 @@
 				<div class="container">
 					<div class="row">
 
-						<div class="4u 12u(mobile)">
-                        <a href="https://www.meetup.com/Manchester-Grey-Hats/events/upcoming">
+                        <a class="4u 12u(mobile)" href="https://www.meetup.com/Manchester-Grey-Hats/events/upcoming">
 							<section class="box style1">
 								<span class="icon featured fa-calendar-o"></span>
 								<h3>Events</h3>
 								<p>We try to meet at least once a month. See what we're up to</p>
 							</section>
-                        </a>
-						</div>
-						<div class="4u 12u(mobile)">
-                        <a href="https://blog.manchestergreyhats.co.uk">
+						</a>
+                        <a  class="4u 12u(mobile)" href="https://blog.manchestergreyhats.co.uk">
 							<section class="box style1">
 								<span class="icon featured fa-file-text-o"></span>
 								<h3>Blog</h3>
 								<p>Check out our community blog. Submitting a article is crazy easy!</p>
 							</section>
-                        </a>
-						</div>
-						<div class="4u 12u(mobile)">
-                        <a href="#">
+						</a>
+                        <a class="4u 12u(mobile)" href="#">
 							<section class="box style1">
 								<span class="icon featured fa-laptop"></span>
 								<h3>Projects</h3>
 								<p>We often work on cool projects together. Our status can be seen here.</p>
 							</section>
-                        </a>
-						</div>
-						<div class="4u 12u(mobile)">
-                        <a href="https://ctftime.org/team/45457">
+						</a>
+                        <a class="4u 12u(mobile)" href="https://ctftime.org/team/45457">
 							<section class="box style1">
 								<span class="icon featured fa-flag-o"></span>
 								<h3>CTFs</h3>
 								<p>We have a small CTF team. Let us know if you want to get involved.</p>
 							</section>
-                        </a>
-						</div>
-						<div class="4u 12u(mobile)">
-                        <a href="#">
+						</a>
+                        <a class="4u 12u(mobile)" href="#">
 							<section class="box style1">
 								<span class="icon featured fa-flag-o"></span>
 								<h3>Podcast</h3>
 								<p>Listen to us discuss nonsense and cyber security.</p>
 							</section>
-                        </a>
-						</div>
+						</a>
 					</div>
 				</div>
 			</article>

--- a/index.html
+++ b/index.html
@@ -16,40 +16,40 @@
 	</head>
 	<body>
 		<!-- Nav -->
-			<nav id="nav">
-		HackTheBox Team Score:<script src="https://www.hackthebox.eu/badge/team/189"></script>!
-				<ul class="container">
-					<li><a href="#top">Top</a></li>
-					<li><a href="https://blog.manchestergreyhats.co.uk/">Blog</a></li>
-					<li><a href="#about">About</a></li>
-					<li><a href="#contact">Contact</a></li>
-				</ul>
-			</nav>
+		<nav id="nav">
+			HackTheBox Team Score:<script src="https://www.hackthebox.eu/badge/team/189"></script>!
+			<ul class="container">
+				<li><a href="#top">Top</a></li>
+				<li><a href="https://blog.manchestergreyhats.co.uk/">Blog</a></li>
+				<li><a href="#about">About</a></li>
+				<li><a href="#contact">Contact</a></li>
+			</ul>
+		</nav>
 
 		<!-- Home -->
-			<div class="wrapper style1 first">
-				<article class="container" id="top">
-					<div class="row">
-						<div class="4u 12u(mobile)">
-							<span class="image fit"><img src="images/pic00.jpg" alt="" /></span>
-						</div>
-						<div class="8u 12u(mobile)">
-							<header>
-								<h1>Manchester Grey Hats</h1>
-							</header>
-							<p>Hack the planet! Fourth Wednesday of the month, 7PM at MadLab, Manchester</p>
-
-						</div>
+		<div class="wrapper style1 first">
+			<article class="container" id="top">
+				<div class="row">
+					<div class="4u 12u(mobile)">
+						<span class="image fit"><img src="images/pic00.jpg" alt="" /></span>
 					</div>
-				</article>
-			</div>
+					<div class="8u 12u(mobile)">
+						<header>
+							<h1>Manchester Grey Hats</h1>
+						</header>
+						<p>Hack the planet! Fourth Wednesday of the month, 7PM at MadLab, Manchester</p>
+
+					</div>
+				</div>
+			</article>
+		</div>
 
 		<!-- Work -->
-			<div class="wrapper style2">
-				<article id="about">
-					<header>
-						<h2>Who are we?</h2>
-						<p>Manchester Grey Hats is a place for all those interested in hacking and cyber security to learn and share. We run capture the flags, workshops and perform/present security research. 
+		<div class="wrapper style2">
+			<article id="about">
+				<header>
+					<h2>Who are we?</h2>
+					<p>Manchester Grey Hats is a place for all those interested in hacking and cyber security to learn and share. We run capture the flags, workshops and perform/present security research.
 
 We encourage all skill levels and those from all backgrounds. Are you an aspiring hacker or a developer thinking about security? Come along and learn. Presenting is open to all members, so if you have something you’d like to present but aren’t ready for the big conferences, get in touch.
 
@@ -57,116 +57,116 @@ Said best by The Mentor – “This is our world now… the world of the electro
 
 Although we meet face to face once a month, MGH is mostly an online community. We encourge people to join us in person for workshops and events but if you can't, join us on Slack and our live stream.
 </p>
-					</header>
-					<div class="container">
-						<div class="row">
+				</header>
+				<div class="container">
+					<div class="row">
 
-							<div class="4u 12u(mobile)">
-                            <a href="https://www.meetup.com/Manchester-Grey-Hats/events/upcoming">
-								<section class="box style1">
-									<span class="icon featured fa-calendar-o"></span>
-									<h3>Events</h3>
-									<p>We try to meet at least once a month. See what we're up to</p>
-								</section>
-                            </a>
-							</div>
-							<div class="4u 12u(mobile)">
-                            <a href="https://blog.manchestergreyhats.co.uk">
-								<section class="box style1">
-									<span class="icon featured fa-file-text-o"></span>
-									<h3>Blog</h3>
-									<p>Check out our community blog. Submitting a article is crazy easy!</p>
-								</section>
-                            </a>
-							</div>
-							<div class="4u 12u(mobile)">
-                            <a href="#">
-								<section class="box style1">
-									<span class="icon featured fa-laptop"></span>
-									<h3>Projects</h3>
-									<p>We often work on cool projects together. Our status can be seen here.</p>
-								</section>
-                            </a>
-							</div>
-							<div class="4u 12u(mobile)">
-                            <a href="https://ctftime.org/team/45457">
-								<section class="box style1">
-									<span class="icon featured fa-flag-o"></span>
-									<h3>CTFs</h3>
-									<p>We have a small CTF team. Let us know if you want to get involved.</p>
-								</section>
-                            </a>
-							</div>
-							<div class="4u 12u(mobile)">
-                            <a href="#">
-								<section class="box style1">
-									<span class="icon featured fa-flag-o"></span>
-									<h3>Podcast</h3>
-									<p>Listen to us discuss nonsense and cyber security.</p>
-								</section>
-                            </a>
-							</div>
+						<div class="4u 12u(mobile)">
+                        <a href="https://www.meetup.com/Manchester-Grey-Hats/events/upcoming">
+							<section class="box style1">
+								<span class="icon featured fa-calendar-o"></span>
+								<h3>Events</h3>
+								<p>We try to meet at least once a month. See what we're up to</p>
+							</section>
+                        </a>
+						</div>
+						<div class="4u 12u(mobile)">
+                        <a href="https://blog.manchestergreyhats.co.uk">
+							<section class="box style1">
+								<span class="icon featured fa-file-text-o"></span>
+								<h3>Blog</h3>
+								<p>Check out our community blog. Submitting a article is crazy easy!</p>
+							</section>
+                        </a>
+						</div>
+						<div class="4u 12u(mobile)">
+                        <a href="#">
+							<section class="box style1">
+								<span class="icon featured fa-laptop"></span>
+								<h3>Projects</h3>
+								<p>We often work on cool projects together. Our status can be seen here.</p>
+							</section>
+                        </a>
+						</div>
+						<div class="4u 12u(mobile)">
+                        <a href="https://ctftime.org/team/45457">
+							<section class="box style1">
+								<span class="icon featured fa-flag-o"></span>
+								<h3>CTFs</h3>
+								<p>We have a small CTF team. Let us know if you want to get involved.</p>
+							</section>
+                        </a>
+						</div>
+						<div class="4u 12u(mobile)">
+                        <a href="#">
+							<section class="box style1">
+								<span class="icon featured fa-flag-o"></span>
+								<h3>Podcast</h3>
+								<p>Listen to us discuss nonsense and cyber security.</p>
+							</section>
+                        </a>
 						</div>
 					</div>
-				</article>
-			</div>
+				</div>
+			</article>
+		</div>
 
 	
 
 		<!-- Contact -->
-			<div class="wrapper style4">
-				<article id="contact" class="container 50%">
-					<header>
-						<p>The best ways to contact us is though email, slack or meetup</p>
-					</header>
-					<div>
+		<div class="wrapper style4">
+			<article id="contact" class="container 50%">
+				<header>
+					<p>The best ways to contact us is though email, slack or meetup</p>
+				</header>
+				<div>
 
-						<div class="row">
-							<div class="12u">
-								<hr />
+					<div class="row">
+						<div class="12u">
+							<hr />
 
-								<h3>Find us on ...</h3>
-								<ul class="social">
-									<li><a href="https://twitter.com/mcrgreyhats" class="icon fa-twitter"><span class="label">Twitter</span></a></li>
-									<li><a href="https://github.com/ManchesterGreyHats" class="icon fa-github"><span class="label">Github</span></a></li>
-									<li><a href="https://www.youtube.com/channel/UCzkeKUhPDOS8S_Rvx4P5huQ" class="icon fa-youtube"><span class="label">YouTube</span></a></li>
-									<li><a href="https://www.meetup.com/Manchester-Grey-Hats/" class="icon fa-meetup"><span class="label">Meetup</span></a></li>
-									<li><a href="mailto:jay@manchestergreyhats.co.uk" class="icon fa-envelope-o"><span class="label">Email</span></a></li>
-									<li><a href="https://reddit.com/r/manchestergreyhats" class="icon fa-reddit"><span class="label">Email</span></a></li>
-                                    <li><a href="https://join.slack.com/t/manchestergreyhats/shared_invite/enQtMjQ2MDk3MDMwNzA3LTkwNmIxNzY5NWE2YmMxZTAzNmZkZmZjNDg4ZjU1OTc3MTFkNDYwMzBjYzNmM2I0ZGExZTE4OWI2MjEzYTg3OGU" class="icon fa-slack"><span class="label">Slack</span></a></li>
-						<p>
-									<!--
-									<li><a href="#" class="icon fa-rss"><span>RSS</span></a></li>
-									<li><a href="#" class="icon fa-instagram"><span>Instagram</span></a></li>
-									<li><a href="#" class="icon fa-foursquare"><span>Foursquare</span></a></li>
-									<li><a href="#" class="icon fa-skype"><span>Skype</span></a></li>
-									<li><a href="#" class="icon fa-soundcloud"><span>Soundcloud</span></a></li>
-									<li><a href="#" class="icon fa-youtube"><span>YouTube</span></a></li>
-									<li><a href="#" class="icon fa-blogger"><span>Blogger</span></a></li>
-									<li><a href="#" class="icon fa-flickr"><span>Flickr</span></a></li>
-									<li><a href="#" class="icon fa-vimeo"><span>Vimeo</span></a></li>
-									-->
-								</ul>
-								<hr />
-							</div>
+							<h3>Find us on ...</h3>
+							<ul class="social">
+								<li><a href="https://twitter.com/mcrgreyhats" class="icon fa-twitter"><span class="label">Twitter</span></a></li>
+								<li><a href="https://github.com/ManchesterGreyHats" class="icon fa-github"><span class="label">Github</span></a></li>
+								<li><a href="https://www.youtube.com/channel/UCzkeKUhPDOS8S_Rvx4P5huQ" class="icon fa-youtube"><span class="label">YouTube</span></a></li>
+								<li><a href="https://www.meetup.com/Manchester-Grey-Hats/" class="icon fa-meetup"><span class="label">Meetup</span></a></li>
+								<li><a href="mailto:jay@manchestergreyhats.co.uk" class="icon fa-envelope-o"><span class="label">Email</span></a></li>
+								<li><a href="https://reddit.com/r/manchestergreyhats" class="icon fa-reddit"><span class="label">Email</span></a></li>
+                                <li><a href="https://join.slack.com/t/manchestergreyhats/shared_invite/enQtMjQ2MDk3MDMwNzA3LTkwNmIxNzY5NWE2YmMxZTAzNmZkZmZjNDg4ZjU1OTc3MTFkNDYwMzBjYzNmM2I0ZGExZTE4OWI2MjEzYTg3OGU" class="icon fa-slack"><span class="label">Slack</span></a></li>
+					<p>
+								<!--
+								<li><a href="#" class="icon fa-rss"><span>RSS</span></a></li>
+								<li><a href="#" class="icon fa-instagram"><span>Instagram</span></a></li>
+								<li><a href="#" class="icon fa-foursquare"><span>Foursquare</span></a></li>
+								<li><a href="#" class="icon fa-skype"><span>Skype</span></a></li>
+								<li><a href="#" class="icon fa-soundcloud"><span>Soundcloud</span></a></li>
+								<li><a href="#" class="icon fa-youtube"><span>YouTube</span></a></li>
+								<li><a href="#" class="icon fa-blogger"><span>Blogger</span></a></li>
+								<li><a href="#" class="icon fa-flickr"><span>Flickr</span></a></li>
+								<li><a href="#" class="icon fa-vimeo"><span>Vimeo</span></a></li>
+								-->
+							</ul>
+							<hr />
 						</div>
 					</div>
-					<footer>
-						<ul id="copyright">
-							<li>&copy; Untitled. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
-						</ul>
-					</footer>
-				</article>
-			</div>
+				</div>
+				<footer>
+					<ul id="copyright">
+						<li>&copy; Untitled. All rights reserved.</li><li>Design: <a href="http://html5up.net">HTML5 UP</a></li>
+					</ul>
+				</footer>
+			</article>
+		</div>
 
 		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/jquery.scrolly.min.js"></script>
-			<script src="assets/js/skel.min.js"></script>
-			<script src="assets/js/skel-viewport.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->
-			<script src="assets/js/main.js"></script>
+		<script src="assets/js/jquery.min.js"></script>
+		<script src="assets/js/jquery.scrolly.min.js"></script>
+		<script src="assets/js/skel.min.js"></script>
+		<script src="assets/js/skel-viewport.min.js"></script>
+		<script src="assets/js/util.js"></script>
+		<!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->
+		<script src="assets/js/main.js"></script>
 
 	</body>
 </html>


### PR DESCRIPTION
The Manchester Grey Hats homepage annoyed me enough that I felt the need to fix the obvious… and once I started I got a bit carried away. Tried not to change the look & feel and to stick to fixing things that were broken/weird including:

* Tidies up the order of the HTML (e.g. site name earlier in the page)
* Adds a custom mcrgreyhats.css file for custom CSS so that original theme is unchanged.
* Makes hackthebox widget look less broken
* Improves general appearance on mobile and tablet sized browsers (e.g. bigger text/tap areas)
* Fixes click/hover area for the larger clickable buttons/sections
* Fixed social media icons colours on hover

If there's anything that's gone too far or that would be better the old way I'm happy to undo any specific bits.

Desktop Before:
![mcrgreyhats-desktop-before](https://user-images.githubusercontent.com/394645/38958119-35858dfe-4354-11e8-8481-252b6fcff165.png)
Desktop After:
![mcrgreyhats-desktop-after](https://user-images.githubusercontent.com/394645/38958116-355679ba-4354-11e8-82d7-36df73ed2bfb.png)
Mobile Before:
![mcrgreyhats-mobile-before](https://user-images.githubusercontent.com/394645/38958120-359ae85c-4354-11e8-9b0e-61651182440c.png)
Mobile After:
![mcrgreyhats-mobile-after](https://user-images.githubusercontent.com/394645/38958117-356c2468-4354-11e8-806d-1c1b45d60ea8.png)
